### PR TITLE
Automated predictions, DATA_DICTIONARY, cricinfo default

### DIFF
--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -62,6 +62,7 @@ jobs:
           CACHE_DIR: ${{ runner.temp }}/prediction_caches
           OUTPUT_DIR: ${{ runner.temp }}/predictions_output
           UPLOAD_PREDICTIONS: 'true'
+          DAYS_AHEAD: ${{ github.event.inputs.days_ahead || '14' }}
         run: |
           Rscript data-raw/models/pre-match/run_predictions_gha.R
 

--- a/.github/workflows/predictions-pipeline.yml
+++ b/.github/workflows/predictions-pipeline.yml
@@ -1,0 +1,112 @@
+name: Predictions Pipeline
+
+on:
+  repository_dispatch:
+    types: [cricsheet-complete]
+  workflow_dispatch:
+    inputs:
+      days_ahead:
+        description: 'Days ahead to look for fixtures (default 14)'
+        type: number
+        default: 14
+        required: false
+
+env:
+  GITHUB_PAT: ${{ secrets.WORKFLOW_PAT }}
+  R_KEEP_PKG_SOURCE: yes
+
+jobs:
+  predict:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+
+      - name: Setup R dependencies
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          cache-version: 1
+          extra-packages: |
+            any::devtools
+            any::piggyback
+            any::arrow
+            any::xgboost
+            any::dplyr
+            any::DBI
+            any::duckdb
+            any::cli
+            any::httr2
+          needs: |
+            devtools
+
+      - name: Run predictions
+        id: predict
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          CACHE_DIR: ${{ runner.temp }}/prediction_caches
+          OUTPUT_DIR: ${{ runner.temp }}/predictions_output
+          UPLOAD_PREDICTIONS: 'true'
+        run: |
+          Rscript data-raw/models/pre-match/run_predictions_gha.R
+
+      - name: Pipeline summary
+        if: always()
+        run: |
+          echo "## Bouncer Predictions Pipeline" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Date:** $(date +'%Y-%m-%d %H:%M UTC')" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Predictions:** ${{ steps.predict.outputs.prediction_count || 'N/A' }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Trigger blog data build
+        if: success() && steps.predict.outputs.prediction_count != ''
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+        run: |
+          gh api repos/peteowen1/bouncerdata/dispatches \
+            -f event_type=predictions-complete
+          echo "Triggered build-blog-data.yml in bouncerdata"
+
+      - name: Create issue on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = `Predictions Pipeline Failed - ${new Date().toISOString().split('T')[0]}`;
+            const body = `## Workflow Failure\n\nThe predictions pipeline failed.\n\n- **Run ID**: ${{ github.run_id }}\n- **Run URL**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\n- **Triggered by**: ${{ github.event_name }}\n\nPlease check the workflow logs.`;
+
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'workflow-failure,predictions'
+            });
+
+            const today = new Date().toISOString().split('T')[0];
+            const existingIssue = issues.data.find(i => i.title.includes(today));
+
+            if (!existingIssue) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: body,
+                labels: ['workflow-failure', 'predictions']
+              });
+            }

--- a/DATA_DICTIONARY.md
+++ b/DATA_DICTIONARY.md
@@ -1,0 +1,386 @@
+# Bouncer Data Dictionary
+
+Column definitions for all DuckDB tables and computed features in the bouncer cricket analytics pipeline. Tables are per-format (`t20`, `odi`, `test`) unless noted.
+
+---
+
+## 1. Core Match Data (`cricsheet.matches`)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `match_id` | integer | Unique match identifier (Cricsheet registry number) |
+| `match_type` | character | `T20`, `IT20`, `ODI`, `ODM`, `Test`, `MDM` |
+| `match_date` | date | Match start date |
+| `season` | character | Season/year identifier |
+| `gender` | character | `male` or `female` |
+| `venue` | character | Ground/stadium name |
+| `city` | character | City name |
+| `team1` | character | First team listed (usually batting first) |
+| `team2` | character | Second team |
+| `toss_winner` | character | Team winning the toss |
+| `toss_decision` | character | `bat` or `field` |
+| `outcome_winner` | character | Winning team (NULL for ties/draws/no result) |
+| `outcome_type` | character | `wins`, `tie`, `no result`, `draw` |
+| `outcome_method` | character | `DLS`, `bowl-out`, etc. (NULL if normal) |
+| `event_name` | character | Tournament/series name |
+| `event_match_number` | integer | Match number within event |
+| `is_knockout` | logical | Knockout/playoff match (computed from event metadata) |
+| `event_tier` | integer | 1-4 quality tier (1=ICC events, 4=associate) |
+| `missing_data` | logical | Data completeness flag |
+
+## 2. Ball-by-Ball Data (`cricsheet.deliveries`)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `delivery_id` | character | Unique ID: `"{match_id}_{batting_team}_{innings}_{over:03d}_{ball:02d}"` |
+| `match_id` | integer | Foreign key to `cricsheet.matches` |
+| `innings` | integer | 1 = batting first, 2 = chasing (3/4 for Tests) |
+| `batting_team` | character | Team batting this delivery |
+| `bowling_team` | character | Team bowling this delivery |
+| `over` | integer | Over number (0-indexed in raw data) |
+| `ball` | integer | Ball within over (0-5) |
+| `batter_id` | character | Cricsheet player registry ID — batter on strike |
+| `bowler_id` | character | Cricsheet player registry ID — bowler |
+| `non_striker_id` | character | Batter at non-striker's end |
+| `runs_batter` | integer | Runs scored by batter (0-6, excludes extras) |
+| `runs_extras` | integer | Extra runs (wides, no-balls, byes, leg-byes) |
+| `runs_total` | integer | Total runs from this delivery (`runs_batter + runs_extras`) |
+| `is_wicket` | logical | TRUE if a batsman was dismissed |
+| `wicket_kind` | character | Dismissal type: bowled, caught, lbw, run out, stumped, etc. |
+| `player_out_id` | character | Player dismissed (may differ from batter for run outs) |
+| `is_wide` | logical | Wide ball |
+| `is_noball` | logical | No-ball |
+| `is_extra` | logical | Any extra delivery |
+
+### Supplementary Delivery Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `has_review` | logical | DRS review taken on this delivery |
+| `review_by` | character | Team requesting review |
+| `review_decision` | character | Umpire decision after review |
+| `has_replacement` | logical | Player replacement occurred |
+| `replacement_in` | character | Incoming replacement player |
+| `replacement_out` | character | Outgoing player |
+| `replacement_reason` | character | `injury`, `absent`, etc. |
+
+## 3. Player Skill Indices (`main.{format}_player_skill`)
+
+Residual-based EMA tracking how much a player deviates from the agnostic baseline expectation. Updated per delivery.
+
+| Column | Type | Start | Description |
+|--------|------|-------|-------------|
+| `delivery_id` | character | — | Foreign key to deliveries |
+| `batter_id` | character | — | Player batting |
+| `bowler_id` | character | — | Player bowling |
+| `batter_scoring_index` | numeric | 0 | Runs deviation from expected (residual EMA). Positive = scores more than expected |
+| `batter_survival_rate` | numeric | ~0.95 | Probability of surviving each ball (absolute EMA on 0/1 outcome) |
+| `batter_balls_faced` | integer | 0 | Cumulative deliveries faced (drives adaptive alpha) |
+| `bowler_economy_index` | numeric | 0 | Runs conceded deviation (residual EMA). Negative = more economical than expected |
+| `bowler_strike_rate` | numeric | ~0.05 | Wicket-taking probability per ball (absolute EMA) |
+| `bowler_balls_bowled` | integer | 0 | Cumulative deliveries bowled |
+
+**Update formula:** `new = (1 - alpha) * old + alpha * observation`
+- Indices use `residual` as observation (deviation from agnostic expected)
+- Rates use raw outcome (0 or 1 for survival/wicket)
+- Alpha decreases with experience: `alpha = alpha_min + (alpha_max - alpha_min) * exp(-deliveries / halflife)`
+
+## 4. Team Skill Indices (`main.{format}_team_skill`)
+
+Same EMA approach as player skills but at team level. Alpha = 50% of player alpha (teams change composition slowly).
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `batting_team_runs_skill` | numeric | Runs deviation when batting (positive = scores more) |
+| `batting_team_wicket_skill` | numeric | Wicket rate deviation when batting (negative = loses fewer) |
+| `bowling_team_runs_skill` | numeric | Runs deviation when bowling (negative = concedes fewer) |
+| `bowling_team_wicket_skill` | numeric | Wicket rate deviation when bowling (positive = takes more) |
+| `batting_team_balls` | integer | Cumulative balls batted by team |
+| `bowling_team_balls` | integer | Cumulative balls bowled by team |
+
+## 5. Venue Skill Indices (`main.{format}_venue_skill`)
+
+Per-venue characteristics. Lowest alpha (venues change slowest). Split into session (short-term) and permanent (long-term).
+
+| Column | Type | Method | Description |
+|--------|------|--------|-------------|
+| `venue_run_rate` | numeric | Residual EMA | Runs deviation from format average |
+| `venue_wicket_rate` | numeric | Residual EMA | Wicket deviation from format average |
+| `venue_boundary_rate` | numeric | Raw EMA | Boundary (4s + 6s) probability — no agnostic baseline |
+| `venue_dot_rate` | numeric | Raw EMA | Dot ball probability — no agnostic baseline |
+| `venue_balls` | integer | — | Total deliveries at venue |
+| `canonical_venue` | character | — | Standardized venue name (handles aliases) |
+
+## 6. 3-Way ELO (`main.{format}_3way_elo`)
+
+Per-delivery ELO ratings decomposing each outcome into batter, bowler, and venue contributions. All start at 1400, bounded 1000-1800 (venue permanent: 1200-1600).
+
+### Run ELO Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `batter_run_elo_before` / `_after` | numeric | Batter's run-scoring ELO (higher = scores more) |
+| `bowler_run_elo_before` / `_after` | numeric | Bowler's run-prevention ELO (higher = concedes fewer) |
+| `venue_perm_run_elo_before` / `_after` | numeric | Long-term venue run tendency (~3yr decay) |
+| `venue_session_run_elo_before` / `_after` | numeric | Short-term pitch/conditions effect (resets each match to 1400) |
+
+### Wicket ELO Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `batter_wicket_elo_before` / `_after` | numeric | Batter's survival ELO (higher = harder to dismiss) |
+| `bowler_wicket_elo_before` / `_after` | numeric | Bowler's wicket-taking ELO (higher = takes more) |
+| `venue_perm_wicket_elo_before` / `_after` | numeric | Long-term venue wicket tendency |
+| `venue_session_wicket_elo_before` / `_after` | numeric | Short-term pitch wicket effect |
+
+### K-Factor Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `k_batter_run` | numeric | Dynamic learning rate for batter (decreases with experience) |
+| `k_bowler_run` | numeric | Dynamic learning rate for bowler |
+| `k_venue_perm_run` | numeric | Dynamic learning rate for venue permanent |
+| `k_venue_session_run` | numeric | Dynamic learning rate for venue session |
+| `days_inactive_batter` | numeric | Days since last match (drives decay toward replacement level) |
+| `days_inactive_bowler` | numeric | Days since last match |
+
+### Attribution Weights (format-gender specific)
+
+| Component | Men's T20 | Men's ODI | Men's Test | Description |
+|-----------|-----------|-----------|------------|-------------|
+| `W_BATTER` | 0.612 | varies | varies | Batter's share of outcome |
+| `W_BOWLER` | 0.311 | varies | varies | Bowler's share |
+| `W_VENUE_SESSION` | 0.062 | varies | varies | Short-term pitch/conditions |
+| `W_VENUE_PERM` | 0.015 | varies | varies | Long-term ground characteristics |
+
+Weights differ by format, gender, and dimension (run vs wicket). See `get_run_elo_weights()` / `get_wicket_elo_weights()` in `R/constants_3way.R`.
+
+## 7. Score Projection (`main.{format}_score_projection`)
+
+Projects final innings totals from any game state. Used for margin calculation and live predictions.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `delivery_id` | character | Foreign key |
+| `current_score` | integer | Runs scored at this delivery |
+| `wickets_fallen` | integer | Wickets lost |
+| `balls_bowled` | integer | Balls faced in innings |
+| `balls_remaining` | integer | Balls left (0 for Tests) |
+| `wickets_remaining` | integer | `10 - wickets_fallen` |
+| `resource_remaining` | numeric | Resources left (0-1), see formula below |
+| `resource_used` | numeric | `1 - resource_remaining` |
+| `eis_agnostic` | integer | Expected Initial Score — format average |
+| `eis_full` | integer | Expected Initial Score — team/venue adjusted |
+| `projected_agnostic` | integer | Projected total using format average |
+| `projected_full` | integer | Projected total using team/venue skills |
+| `projection_change_agnostic` | integer | Change from previous delivery |
+| `projection_change_full` | integer | Change from previous delivery |
+| `final_innings_total` | integer | Actual final score (for validation) |
+
+## 8. Team ELO (`main.team_elo`)
+
+Game-level team ratings based on match results.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `match_id` | integer | Match identifier |
+| `team` | character | Team name |
+| `elo_result` | numeric | Result-based ELO rating |
+| `elo_roster_combined` | numeric | Aggregated ELO from individual player ratings |
+| `matches_played` | integer | Experience indicator |
+
+## 9. Feature Engineering (Computed Columns)
+
+Columns computed by `R/feature_engineering.R` and added to delivery data during pipeline processing.
+
+### Phase & Context
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `phase` | factor | `powerplay`, `middle`, `death` (T20/ODI) or `new_ball`, `middle`, `old_ball` (Test) |
+| `overs_into_phase` | numeric | Overs elapsed in current phase |
+| `overs_completed` | numeric | Decimal overs completed (e.g., 10.3) |
+| `overs_remaining` | numeric | Overs left in innings (NA for Tests) |
+| `balls_remaining` | integer | Balls left |
+| `total_runs` | integer | Cumulative innings score |
+| `wickets_fallen` | integer | Cumulative wickets in innings |
+| `runs_difference` | integer | `team1_score - current_score` (2nd innings pressure) |
+| `is_wicket_int` | integer | Integer version (0/1) of `is_wicket` |
+| `is_four` | logical | 4 runs scored |
+| `is_six` | logical | 6 runs scored |
+| `is_boundary` | integer | `as.integer(is_four | is_six)` |
+| `is_dot` | integer | `as.integer(runs_total == 0 & !is_wicket)` |
+
+### Rolling Momentum
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `runs_last_12_balls` | integer | Runs in last 2 overs |
+| `runs_last_24_balls` | integer | Runs in last 4 overs |
+| `dots_last_12_balls` | integer | Dot balls in last 2 overs |
+| `dots_last_24_balls` | integer | Dot balls in last 4 overs |
+| `boundaries_last_12_balls` | integer | Boundaries in last 2 overs |
+| `boundaries_last_24_balls` | integer | Boundaries in last 4 overs |
+| `wickets_last_12_balls` | integer | Wickets in last 2 overs |
+| `wickets_last_24_balls` | integer | Wickets in last 4 overs |
+| `runs_last_3_overs` | integer | Runs in last 3 overs |
+| `runs_last_6_overs` | integer | Runs in last 6 overs |
+| `rr_last_3_overs` | numeric | Run rate over last 3 overs |
+| `rr_last_6_overs` | numeric | Run rate over last 6 overs |
+| `over_runs` | integer | Runs in current over so far |
+| `over_wickets` | integer | Wickets in current over so far |
+
+### Chase Metrics (2nd innings only)
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `runs_needed` | integer | Runs still required to win |
+| `wickets_in_hand` | integer | `10 - wickets_fallen` |
+| `required_run_rate` | numeric | Runs per over needed to win |
+| `rr_differential` | numeric | Required RR minus current RR |
+| `balls_per_run_needed` | numeric | Balls available per run required |
+| `balls_per_wicket_available` | numeric | Balls per remaining wicket |
+| `chase_buffer` | integer | `balls_remaining - runs_needed` |
+| `chase_buffer_ratio` | numeric | `chase_buffer / balls_remaining` |
+| `theoretical_min_balls` | integer | `ceiling(runs_needed / 6)` — minimum balls to reach target |
+| `balls_surplus` | integer | `balls_remaining - theoretical_min_balls` |
+| `is_easy_chase` | integer | `< 1 run/ball needed AND 5+ wickets in hand` |
+| `is_difficult_chase` | integer | `> 2 runs/ball needed OR < 3 wickets left` |
+| `is_death_chase` | logical | Last 4 overs of a chase |
+| `chase_completed` | integer | 1 if `runs_needed <= 0` |
+| `chase_impossible` | integer | 1 if no resources but runs still needed |
+
+## 10. Win Probability & Attribution
+
+Columns from `R/win_probability_added.R` and `R/player_attribution.R`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `predicted_before` | numeric | Model win probability before this delivery |
+| `predicted_after` | numeric | Model win probability after this delivery |
+| `wpa` | numeric | Win Probability Added: `predicted_after - predicted_before` |
+| `batter_wpa` | numeric | WPA credited to batter |
+| `bowler_wpa` | numeric | WPA credited to bowler |
+| `expected_runs` | numeric | Expected runs per ball from model |
+| `era` | numeric | Expected Runs Added: `actual - expected` |
+| `batter_era` | numeric | ERA credited to batter |
+| `bowler_era` | numeric | ERA credited to bowler |
+
+## 11. Pre-Match Prediction Features
+
+Aggregated features for match-level prediction model. Built by `R/pre_match_features.R`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `team1_elo_result` | numeric | Team 1 match-result ELO |
+| `team2_elo_result` | numeric | Team 2 match-result ELO |
+| `elo_diff_result` | numeric | `team1_elo - team2_elo` |
+| `team1_elo_roster` | numeric | Team 1 roster-aggregated ELO |
+| `team2_elo_roster` | numeric | Team 2 roster-aggregated ELO |
+| `team1_form_last5` | numeric | Team 1 win rate in last 5 matches |
+| `team2_form_last5` | numeric | Team 2 win rate in last 5 matches |
+| `team1_h2h_total` | integer | Head-to-head matches played |
+| `team1_h2h_wins` | integer | Team 1 head-to-head wins |
+| `team1_bat_scoring_avg` | numeric | Average batting scoring index across roster |
+| `team1_bat_scoring_top5` | numeric | Top 5 batters' average scoring index |
+| `team1_bat_survival_avg` | numeric | Average batter survival rate |
+| `team1_bowl_economy_avg` | numeric | Average bowler economy index |
+| `team1_bowl_economy_top5` | numeric | Top 5 bowlers' economy index |
+| `team1_bowl_strike_avg` | numeric | Average bowler strike rate |
+| `bat_scoring_diff` | numeric | `team1 - team2` batting index difference |
+| `bowl_economy_diff` | numeric | `team2 - team1` bowling economy difference |
+| `team1_won_toss` | logical | Team 1 won the toss |
+| `toss_elect_bat` | logical | Toss winner elected to bat |
+| `venue_avg_score` | integer | Historical average score at venue |
+| `venue_chase_success_rate` | numeric | Historical chase success rate at venue |
+| `team1_team_runs_skill` | numeric | Team 1 batting skill index |
+| `team2_team_runs_skill` | numeric | Team 2 batting skill index |
+
+(Columns repeated symmetrically for `team2_*` where applicable.)
+
+## 12. Cricinfo Hawkeye Data (`cricinfo.balls`)
+
+Optional tracking data from ESPN Cricinfo. Available for ~3,700 matches with ball-by-ball Hawkeye data.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `wagonX` | numeric | Wagon wheel x coordinate (where ball went) |
+| `wagonY` | numeric | Wagon wheel y coordinate |
+| `wagonZone` | character | Field zone the ball was hit to |
+| `pitchLine` | character | `off`, `leg`, `middle` — where ball pitched |
+| `pitchLength` | character | `full`, `good`, `short`, `yorker` — length |
+| `shotType` | character | `drive`, `cut`, `pull`, `defense`, etc. |
+| `shotControl` | character | `controlled`, `risky`, `very risky` |
+| `win_probability` | numeric | Hawkeye-computed win probability |
+
+## 13. Centrality / Network Quality
+
+From `R/centrality.R` and `R/centrality_storage.R`. PageRank-based quality adjustment for ELO ratings.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `batter_centrality` | numeric | PageRank score (0-1). Low = inflated ELO from weak opponents |
+| `bowler_centrality` | numeric | PageRank score for bowler |
+| `unique_opponents` | integer | Distinct opponents faced |
+| `avg_opponent_degree` | numeric | Average opponent network connectivity |
+
+## 14. Margin & Outcome
+
+From `R/margin_calculation.R`. Converts all match outcomes to a runs-equivalent margin.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `margin` | numeric | Runs-equivalent margin (positive = team1 won) |
+| `win_type` | character | `runs`, `wickets`, `tie`, `draw`, `no_result` |
+| `wickets_remaining` | integer | For wickets wins: wickets in hand when chase completed |
+| `overs_remaining` | numeric | Cricket notation (e.g., 2.3 = 2 overs 3 balls remaining) |
+
+---
+
+## Key Formulas
+
+### Skill Index Update (per delivery)
+```
+residual = actual_outcome - agnostic_expected
+new_skill = (1 - alpha) * old_skill + alpha * residual
+```
+
+### Adaptive Alpha (learning rate)
+```
+alpha = alpha_min + (alpha_max - alpha_min) * exp(-deliveries / halflife)
+```
+New players learn fast (high alpha), experienced players are stable (low alpha).
+
+### 3-Way ELO Expected Runs
+```
+expected_runs = agnostic_baseline * (1 + (w_batter * (batter_elo - 1400)
+                                        + w_bowler * (1400 - bowler_elo)
+                                        + w_venue_perm * (venue_perm - 1400)
+                                        + w_venue_session * (venue_session - 1400))
+                                       * runs_per_100_elo)
+```
+
+### Score Projection
+```
+resource_remaining = (balls_remaining / max_balls)^z * (wickets_remaining / 10)^y
+projected = current_score + a * eis * resource_remaining
+          + b * current_score * resource_remaining / resource_used
+```
+Parameters `a`, `b`, `z`, `y` are optimized per format-gender-team_type segment.
+
+### Unified Margin (wickets wins → runs equivalent)
+Wickets wins are converted to runs-equivalent using the score projection system, allowing all results to be compared on the same scale.
+
+---
+
+## Format-Specific Constants
+
+| Constant | T20 | ODI | Test |
+|----------|-----|-----|------|
+| Expected runs/ball | 1.138 | 0.782 | 0.518 |
+| Expected wicket/ball | 5.4% | 2.8% | 1.7% |
+| Max balls per innings | 120 | 300 | Variable |
+| Skill alpha (player) | 0.01 | 0.008 | 0.005 |
+| Skill alpha (venue) | 0.002 | 0.001 | 0.0005 |
+| ELO start | 1400 | 1400 | 1400 |
+| Runs per 100 ELO | 0.0745 | 0.0826 | 0.0932 |

--- a/R/cricinfo_data.R
+++ b/R/cricinfo_data.R
@@ -395,8 +395,8 @@ cricinfo_format_sql <- function(column, format) {
 #' @param gender Character. "male", "female", or "all" (default).
 #' @param status Character. Match status filter: "all" (default), "POST"
 #'   (completed), "PRE" (upcoming), "LIVE".
-#' @param source Character. "local" (default) queries DuckDB. "remote"
-#'   downloads fixtures.parquet from the cricinfo GitHub release.
+#' @param source Character. "remote" (default) downloads fixtures.parquet
+#'   from the cricinfo GitHub release. "local" queries DuckDB.
 #'
 #' @return Data frame of fixtures.
 #' @export
@@ -414,7 +414,7 @@ cricinfo_format_sql <- function(column, format) {
 #' }
 load_cricinfo_fixtures <- function(format = "all", gender = "all",
                                     status = "all",
-                                    source = c("local", "remote")) {
+                                    source = c("remote", "local")) {
   source <- match.arg(source)
 
   where_clauses <- character()
@@ -471,7 +471,7 @@ load_cricinfo_fixtures <- function(format = "all", gender = "all",
 #' @param format Character. "t20i", "odi", "test", or "all" (default).
 #' @param gender Character. "male", "female", or "all" (default).
 #' @param days_ahead Integer. Number of days ahead to look. Default 30.
-#' @param source Character. "local" (default) or "remote".
+#' @param source Character. "remote" (default) or "local".
 #'
 #' @return Data frame of upcoming fixtures.
 #' @export
@@ -483,7 +483,7 @@ load_cricinfo_fixtures <- function(format = "all", gender = "all",
 #' }
 get_upcoming_matches <- function(format = "all", gender = "all",
                                   days_ahead = 30,
-                                  source = c("local", "remote")) {
+                                  source = c("remote", "local")) {
   source <- match.arg(source)
 
   fixtures <- load_cricinfo_fixtures(format = format, gender = gender,
@@ -520,7 +520,7 @@ get_upcoming_matches <- function(format = "all", gender = "all",
 #'
 #' @param format Character. "t20i", "odi", "test", or "all" (default).
 #' @param gender Character. "male", "female", or "all" (default).
-#' @param source Character. "local" (default) or "remote".
+#' @param source Character. "remote" (default) or "local".
 #'
 #' @return Data frame of unscraped fixtures.
 #' @export
@@ -531,7 +531,7 @@ get_upcoming_matches <- function(format = "all", gender = "all",
 #' get_unscraped_matches(format = "t20i")
 #' }
 get_unscraped_matches <- function(format = "all", gender = "all",
-                                   source = c("local", "remote")) {
+                                   source = c("remote", "local")) {
   source <- match.arg(source)
 
   fixtures <- load_cricinfo_fixtures(format = format, gender = gender,
@@ -642,7 +642,7 @@ query_cricinfo_table <- function(table, alias, order_cols, match_ids, format,
 #'   If NULL, loads all.
 #' @param format Character. "t20i", "odi", "test", or NULL (all formats).
 #' @param gender Character. "male", "female", or NULL (all genders).
-#' @param source Character. "local" (default) or "remote".
+#' @param source Character. "remote" (default) or "local".
 #'
 #' @return Data frame of ball-by-ball data with Hawkeye columns.
 #' @export
@@ -660,7 +660,7 @@ query_cricinfo_table <- function(table, alias, order_cols, match_ids, format,
 #' }
 load_cricinfo_balls <- function(match_ids = NULL, format = NULL,
                                  gender = NULL,
-                                 source = c("local", "remote")) {
+                                 source = c("remote", "local")) {
   source <- match.arg(source)
   if (source == "remote") {
     return(load_cricinfo_remote("balls", match_ids, format, gender))
@@ -688,7 +688,7 @@ load_cricinfo_balls <- function(match_ids = NULL, format = NULL,
 #' }
 load_cricinfo_match <- function(match_ids = NULL, format = NULL,
                                  gender = NULL,
-                                 source = c("local", "remote")) {
+                                 source = c("remote", "local")) {
   source <- match.arg(source)
   if (source == "remote") {
     return(load_cricinfo_remote("match", match_ids, format, gender))
@@ -716,7 +716,7 @@ load_cricinfo_match <- function(match_ids = NULL, format = NULL,
 #' }
 load_cricinfo_innings <- function(match_ids = NULL, format = NULL,
                                    gender = NULL,
-                                   source = c("local", "remote")) {
+                                   source = c("remote", "local")) {
   source <- match.arg(source)
   if (source == "remote") {
     return(load_cricinfo_remote("innings", match_ids, format, gender))

--- a/data-raw/models/pre-match/run_predictions_gha.R
+++ b/data-raw/models/pre-match/run_predictions_gha.R
@@ -1,0 +1,391 @@
+# run_predictions_gha.R
+# Lightweight prediction script for GitHub Actions.
+#
+# Data source hierarchy (mirrors pannaverse's Opta/FBref pattern):
+#   - Cricinfo = PRIMARY (fixtures, recent results, most up-to-date)
+#   - Cricsheet = SECONDARY (historical coverage for form/H2H/venue stats)
+#   - Prediction caches = RATINGS (player skills, ELOs from heavy pipeline)
+#
+# Downloads prediction caches (parquets) from GitHub releases,
+# loads them into a temporary DuckDB so existing SQL-based
+# feature functions work unchanged, then generates predictions
+# for upcoming fixtures.
+#
+# This script does NOT need the full 18GB DuckDB — it works with
+# ~50MB of cached aggregates from the predictions-cache release.
+#
+# Prerequisites: Run upload_prediction_caches.R locally after
+# the heavy pipeline to populate the predictions-cache release.
+
+# 1. Setup ----
+
+library(DBI)
+library(duckdb)
+library(arrow)
+library(piggyback)
+library(cli)
+library(xgboost)
+
+devtools::load_all()
+
+cli_h1("Bouncer Predictions (GHA)")
+
+REPO <- "peteowen1/bouncerdata"
+FORMATS <- c("t20", "odi", "test")
+
+# Where to download caches
+cache_dir <- Sys.getenv("CACHE_DIR", file.path(tempdir(), "prediction_caches"))
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+
+# 2. Download prediction caches ----
+cli_h2("Downloading prediction caches")
+
+download_cache <- function(filename) {
+  dest <- file.path(cache_dir, filename)
+  if (file.exists(dest)) {
+    cli_alert_info("Already have {filename}")
+    return(TRUE)
+  }
+  tryCatch({
+    pb_download(file = filename, repo = REPO, tag = "predictions-cache",
+                dest = cache_dir)
+    if (file.exists(dest)) {
+      cli_alert_success("Downloaded {filename}")
+      return(TRUE)
+    }
+    cli_alert_warning("File not found: {filename}")
+    return(FALSE)
+  }, error = function(e) {
+    cli_alert_warning("Failed to download {filename}: {e$message}")
+    return(FALSE)
+  })
+}
+
+# Core files
+download_cache("matches.parquet")
+download_cache("match_innings.parquet")
+download_cache("team_elo.parquet")
+download_cache("recent_lineups.parquet")
+
+# Per-format files
+for (fmt in FORMATS) {
+  download_cache(paste0(fmt, "_batter_skill_latest.parquet"))
+  download_cache(paste0(fmt, "_bowler_skill_latest.parquet"))
+  download_cache(paste0(fmt, "_batter_elo_latest.parquet"))
+  download_cache(paste0(fmt, "_bowler_elo_latest.parquet"))
+  download_cache(paste0(fmt, "_prediction_model.ubj"))
+  download_cache(paste0(fmt, "_prediction_features.rds"))
+}
+
+# Download Cricinfo data (primary source — most up-to-date fixtures + results)
+cli_h2("Downloading Cricinfo data (primary source)")
+cricinfo_dir <- file.path(cache_dir, "cricinfo")
+dir.create(cricinfo_dir, showWarnings = FALSE, recursive = TRUE)
+
+for (f in c("fixtures.parquet", "matches.parquet", "innings.parquet")) {
+  tryCatch({
+    pb_download(file = f, repo = REPO, tag = "cricinfo", dest = cricinfo_dir)
+    cli_alert_success("Downloaded cricinfo/{f}")
+  }, error = function(e) {
+    cli_alert_warning("Cricinfo {f} not available: {e$message}")
+  })
+}
+
+# Download Cricsheet matches (secondary source — broader historical coverage)
+cli_h2("Downloading Cricsheet data (secondary source)")
+cricsheet_dir <- file.path(cache_dir, "cricsheet")
+dir.create(cricsheet_dir, showWarnings = FALSE, recursive = TRUE)
+
+tryCatch({
+  pb_download(file = "matches.parquet", repo = REPO, tag = "cricsheet",
+              dest = cricsheet_dir)
+  cli_alert_success("Downloaded cricsheet matches (historical coverage)")
+}, error = function(e) {
+  cli_alert_warning("Could not download cricsheet matches: {e$message}")
+})
+
+# 3. Build temporary DuckDB ----
+cli_h2("Building temporary DuckDB from caches")
+
+db_path <- file.path(tempdir(), "bouncer_predictions.duckdb")
+if (file.exists(db_path)) file.remove(db_path)
+
+conn <- dbConnect(duckdb(), db_path)
+
+# Create schemas
+dbExecute(conn, "CREATE SCHEMA IF NOT EXISTS cricsheet")
+dbExecute(conn, "CREATE SCHEMA IF NOT EXISTS cricinfo")
+dbExecute(conn, "CREATE SCHEMA IF NOT EXISTS main")
+
+# Load Cricinfo fixtures (primary source for upcoming + recent results)
+cricinfo_fixtures_path <- file.path(cache_dir, "cricinfo", "fixtures.parquet")
+if (file.exists(cricinfo_fixtures_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricinfo.fixtures AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", cricinfo_fixtures_path)
+  ))
+  fixture_count <- dbGetQuery(conn, "SELECT COUNT(*) as n FROM cricinfo.fixtures")$n
+  cli_alert_success("Loaded cricinfo fixtures (primary): {format(fixture_count, big.mark=',')} rows")
+}
+
+# Load Cricinfo match metadata
+cricinfo_matches_path <- file.path(cache_dir, "cricinfo", "matches.parquet")
+if (file.exists(cricinfo_matches_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricinfo.matches AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", cricinfo_matches_path)
+  ))
+  cli_alert_success("Loaded cricinfo matches")
+}
+
+# Load Cricinfo innings
+cricinfo_innings_path <- file.path(cache_dir, "cricinfo", "innings.parquet")
+if (file.exists(cricinfo_innings_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricinfo.innings AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", cricinfo_innings_path)
+  ))
+  cli_alert_success("Loaded cricinfo innings")
+}
+
+# Load Cricsheet matches (secondary — broader historical coverage for form/H2H/venue)
+cricsheet_matches_path <- file.path(cache_dir, "cricsheet", "matches.parquet")
+cached_matches_path <- file.path(cache_dir, "matches.parquet")
+
+if (file.exists(cricsheet_matches_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricsheet.matches AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", cricsheet_matches_path)
+  ))
+  cli_alert_success("Loaded cricsheet matches (secondary, historical)")
+} else if (file.exists(cached_matches_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricsheet.matches AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", cached_matches_path)
+  ))
+  cli_alert_success("Loaded matches from prediction cache")
+} else {
+  cli_abort("No matches data available!")
+}
+
+match_count <- dbGetQuery(conn, "SELECT COUNT(*) as n FROM cricsheet.matches")$n
+cli_alert_info("Cricsheet matches loaded: {format(match_count, big.mark=',')} (historical coverage)")
+
+# Load match innings (from prediction cache — exported from DuckDB)
+innings_path <- file.path(cache_dir, "match_innings.parquet")
+if (file.exists(innings_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricsheet.match_innings AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", innings_path)
+  ))
+  cli_alert_success("Loaded match innings")
+}
+
+# Load team ELO
+team_elo_path <- file.path(cache_dir, "team_elo.parquet")
+if (file.exists(team_elo_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE main.team_elo AS SELECT * FROM read_parquet('%s')",
+    gsub("\\\\", "/", team_elo_path)
+  ))
+  cli_alert_success("Loaded team ELO")
+}
+
+# Load player skills and ELO into format-specific tables
+for (fmt in FORMATS) {
+  # Batter skills
+  batter_skill_path <- file.path(cache_dir, paste0(fmt, "_batter_skill_latest.parquet"))
+  bowler_skill_path <- file.path(cache_dir, paste0(fmt, "_bowler_skill_latest.parquet"))
+
+  if (file.exists(batter_skill_path) && file.exists(bowler_skill_path)) {
+    # Create a unified skill table matching the schema expected by existing functions
+    dbExecute(conn, sprintf(
+      "CREATE TABLE main.%s_player_skill AS
+       SELECT b.batter_id, b.match_date, b.batter_scoring_index, b.batter_survival_rate, b.batter_balls_faced,
+              NULL AS bowler_id, NULL AS bowler_economy_index, NULL AS bowler_strike_rate, NULL AS bowler_balls_bowled,
+              NULL AS delivery_id
+       FROM read_parquet('%s') b",
+      fmt, gsub("\\\\", "/", batter_skill_path)
+    ))
+    # Add bowler rows
+    dbExecute(conn, sprintf(
+      "INSERT INTO main.%s_player_skill
+       SELECT NULL, w.match_date, NULL, NULL, NULL,
+              w.bowler_id, w.bowler_economy_index, w.bowler_strike_rate, w.bowler_balls_bowled,
+              NULL
+       FROM read_parquet('%s') w",
+      fmt, gsub("\\\\", "/", bowler_skill_path)
+    ))
+    cli_alert_success("Loaded {fmt} player skills")
+  }
+
+  # Player ELO
+  batter_elo_path <- file.path(cache_dir, paste0(fmt, "_batter_elo_latest.parquet"))
+  bowler_elo_path <- file.path(cache_dir, paste0(fmt, "_bowler_elo_latest.parquet"))
+
+  if (file.exists(batter_elo_path) && file.exists(bowler_elo_path)) {
+    dbExecute(conn, sprintf(
+      "CREATE TABLE main.%s_3way_elo AS
+       SELECT b.batter_id, b.match_date, b.batter_run_elo_after, b.batter_wicket_elo_after,
+              NULL AS bowler_id, NULL AS bowler_run_elo_after, NULL AS bowler_wicket_elo_after,
+              NULL AS delivery_id
+       FROM read_parquet('%s') b",
+      fmt, gsub("\\\\", "/", batter_elo_path)
+    ))
+    dbExecute(conn, sprintf(
+      "INSERT INTO main.%s_3way_elo
+       SELECT NULL, w.match_date, NULL, NULL,
+              w.bowler_id, w.bowler_run_elo_after, w.bowler_wicket_elo_after,
+              NULL
+       FROM read_parquet('%s') w",
+      fmt, gsub("\\\\", "/", bowler_elo_path)
+    ))
+    cli_alert_success("Loaded {fmt} player 3-Way ELO")
+  }
+}
+
+# Load recent lineups into deliveries table (for XI inference)
+lineups_path <- file.path(cache_dir, "recent_lineups.parquet")
+if (file.exists(lineups_path)) {
+  dbExecute(conn, sprintf(
+    "CREATE TABLE cricsheet.deliveries AS
+     SELECT match_id, match_date, team AS batting_team, team AS bowling_team,
+            player_id AS batter_id, player_id AS bowler_id
+     FROM read_parquet('%s')",
+    gsub("\\\\", "/", lineups_path)
+  ))
+  cli_alert_success("Loaded recent lineups for XI inference")
+}
+
+# 4. Get upcoming fixtures ----
+cli_h2("Loading upcoming fixtures")
+
+upcoming <- tryCatch(
+  get_upcoming_matches(source = "remote", days_ahead = 14),
+  error = function(e) {
+    cli_alert_warning("Could not load fixtures from Cricinfo: {e$message}")
+    data.frame()
+  }
+)
+
+if (nrow(upcoming) == 0) {
+  cli_alert_warning("No upcoming matches found in next 14 days")
+  dbDisconnect(conn, shutdown = TRUE)
+  quit(save = "no", status = 0)
+}
+
+cli_alert_success("Found {nrow(upcoming)} upcoming matches")
+
+# 5. Generate predictions ----
+cli_h2("Generating predictions")
+
+# Build home lookups once
+all_matches <- dbGetQuery(conn,
+  "SELECT team1, team2, venue, team_type, gender, match_type FROM cricsheet.matches")
+home_lookups <- build_home_lookups(all_matches)
+
+predictions <- list()
+
+for (i in seq_len(nrow(upcoming))) {
+  fixture <- upcoming[i, ]
+  fmt <- normalize_format(fixture$match_type %||% fixture$format %||% "t20")
+
+  # Load model for this format
+  model_path <- file.path(cache_dir, paste0(fmt, "_prediction_model.ubj"))
+  if (!file.exists(model_path)) {
+    cli_alert_warning("No model for format {fmt}, using ELO-based prediction")
+    model <- NULL
+  } else {
+    model <- xgb.load(model_path)
+  }
+
+  # Try to calculate features and predict
+  tryCatch({
+    match_id <- fixture$match_id %||% fixture$id %||% paste0("upcoming_", i)
+
+    # Check if match exists in DB (for feature calculation)
+    exists_in_db <- dbGetQuery(conn, sprintf(
+      "SELECT COUNT(*) as n FROM cricsheet.matches WHERE match_id = %s",
+      dbQuoteLiteral(conn, as.character(match_id))
+    ))$n > 0
+
+    if (!exists_in_db) {
+      # Insert fixture into matches table for feature calculation
+      dbExecute(conn, sprintf(
+        "INSERT INTO cricsheet.matches (match_id, match_date, match_type, venue, team1, team2,
+         team_type, gender, event_name)
+         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        dbQuoteLiteral(conn, as.character(match_id)),
+        dbQuoteLiteral(conn, as.character(fixture$match_date %||% fixture$date %||% Sys.Date())),
+        dbQuoteLiteral(conn, fixture$match_type %||% fixture$format %||% "T20"),
+        dbQuoteLiteral(conn, fixture$venue %||% "Unknown"),
+        dbQuoteLiteral(conn, fixture$team1 %||% fixture$home_team %||% "TBD"),
+        dbQuoteLiteral(conn, fixture$team2 %||% fixture$away_team %||% "TBD"),
+        dbQuoteLiteral(conn, fixture$team_type %||% "international"),
+        dbQuoteLiteral(conn, fixture$gender %||% "male"),
+        dbQuoteLiteral(conn, fixture$event_name %||% fixture$series %||% NA_character_)
+      ))
+    }
+
+    pred <- predict_match_outcome(
+      match_id = as.character(match_id),
+      model = model,
+      conn = conn,
+      model_type = if (!is.null(model)) "xgboost" else "elo"
+    )
+
+    if (!is.null(pred)) {
+      predictions[[length(predictions) + 1]] <- as.data.frame(pred, stringsAsFactors = FALSE)
+      cli_alert_success("{pred$team1} vs {pred$team2}: {pred$predicted_winner} ({round(pred$confidence * 100, 1)}%)")
+    }
+  }, error = function(e) {
+    cli_alert_warning("Failed to predict fixture {i}: {e$message}")
+  })
+}
+
+# Cleanup DB
+dbDisconnect(conn, shutdown = TRUE)
+if (file.exists(db_path)) file.remove(db_path)
+
+# 6. Export predictions ----
+cli_h2("Exporting predictions")
+
+if (length(predictions) > 0) {
+  pred_df <- do.call(rbind, predictions)
+
+  output_dir <- Sys.getenv("OUTPUT_DIR", file.path(tempdir(), "predictions_output"))
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+  pred_path <- file.path(output_dir, "predictions.parquet")
+  write_parquet(pred_df, pred_path, compression = "zstd")
+  cli_alert_success("Saved {nrow(pred_df)} predictions to {pred_path}")
+
+  pred_csv_path <- file.path(output_dir, "predictions.csv")
+  write.csv(pred_df, pred_csv_path, row.names = FALSE)
+  cli_alert_success("Saved predictions CSV")
+
+  # Upload to predictions-latest release
+  upload_predictions <- as.logical(Sys.getenv("UPLOAD_PREDICTIONS", "true"))
+  if (upload_predictions) {
+    cli_h2("Uploading predictions")
+    tryCatch(
+      pb_release_create(repo = REPO, tag = "predictions-latest", name = "Match Predictions"),
+      error = function(e) cli_alert_info("Release already exists")
+    )
+    pb_upload(pred_path, repo = REPO, tag = "predictions-latest", overwrite = TRUE)
+    pb_upload(pred_csv_path, repo = REPO, tag = "predictions-latest", overwrite = TRUE)
+    cli_alert_success("Uploaded to predictions-latest release")
+  }
+
+  # Write output for GHA summary
+  output_file <- Sys.getenv("GITHUB_OUTPUT", "")
+  if (nzchar(output_file)) {
+    cat(sprintf("prediction_count=%d\n", nrow(pred_df)), file = output_file, append = TRUE)
+    cat(sprintf("formats=%s\n", paste(unique(pred_df$model_type), collapse = ",")),
+        file = output_file, append = TRUE)
+  }
+} else {
+  cli_alert_warning("No predictions generated")
+}
+
+cli_h1("Predictions Complete!")

--- a/data-raw/models/pre-match/run_predictions_gha.R
+++ b/data-raw/models/pre-match/run_predictions_gha.R
@@ -111,6 +111,7 @@ db_path <- file.path(tempdir(), "bouncer_predictions.duckdb")
 if (file.exists(db_path)) file.remove(db_path)
 
 conn <- dbConnect(duckdb(), db_path)
+on.exit(dbDisconnect(conn, shutdown = TRUE))
 
 # Create schemas
 dbExecute(conn, "CREATE SCHEMA IF NOT EXISTS cricsheet")
@@ -261,7 +262,8 @@ if (file.exists(lineups_path)) {
 cli_h2("Loading upcoming fixtures")
 
 upcoming <- tryCatch(
-  get_upcoming_matches(source = "remote", days_ahead = 14),
+  get_upcoming_matches(source = "remote",
+                       days_ahead = as.integer(Sys.getenv("DAYS_AHEAD", "14"))),
   error = function(e) {
     cli_alert_warning("Could not load fixtures from Cricinfo: {e$message}")
     data.frame()
@@ -269,9 +271,9 @@ upcoming <- tryCatch(
 )
 
 if (nrow(upcoming) == 0) {
-  cli_alert_warning("No upcoming matches found in next 14 days")
-  dbDisconnect(conn, shutdown = TRUE)
-  quit(save = "no", status = 0)
+  days <- as.integer(Sys.getenv("DAYS_AHEAD", "14"))
+  cli_alert_warning("No upcoming matches found in next {days} days")
+  quit(save = "no", status = 0)  # on.exit handles disconnect
 }
 
 cli_alert_success("Found {nrow(upcoming)} upcoming matches")
@@ -343,8 +345,7 @@ for (i in seq_len(nrow(upcoming))) {
   })
 }
 
-# Cleanup DB
-dbDisconnect(conn, shutdown = TRUE)
+# Cleanup DB (on.exit handles disconnect, just remove temp file)
 if (file.exists(db_path)) file.remove(db_path)
 
 # 6. Export predictions ----

--- a/data-raw/release/upload_prediction_caches.R
+++ b/data-raw/release/upload_prediction_caches.R
@@ -125,17 +125,24 @@ for (fmt in FORMATS) {
 cli_h2("Exporting player 3-Way ELO (latest per player)")
 
 for (fmt in FORMATS) {
-  elo_table <- paste0(fmt, "_3way_elo")
-
-  # Check if table exists
-  exists_check <- tryCatch(
-    { DBI::dbGetQuery(conn, sprintf("SELECT 1 FROM main.%s LIMIT 1", elo_table)); TRUE },
-    error = function(e) FALSE
+  # Try gender-prefixed table names first (mens_t20_3way_elo), then fallback
+  elo_candidates <- c(
+    paste0("mens_", fmt, "_3way_elo"),
+    paste0(fmt, "_3way_elo")
   )
-  if (!exists_check) {
-    cli_alert_warning("Table {elo_table} not found, skipping")
+  elo_table <- NULL
+  for (candidate in elo_candidates) {
+    exists_check <- tryCatch(
+      { DBI::dbGetQuery(conn, sprintf("SELECT 1 FROM main.%s LIMIT 1", candidate)); TRUE },
+      error = function(e) FALSE
+    )
+    if (exists_check) { elo_table <- candidate; break }
+  }
+  if (is.null(elo_table)) {
+    cli_alert_warning("No 3-Way ELO table found for {fmt} (tried: {paste(elo_candidates, collapse=', ')})")
     next
   }
+  cli_alert_info("Using table: {elo_table}")
 
   export_query_to_parquet(conn, sprintf("
     WITH ranked AS (

--- a/data-raw/release/upload_prediction_caches.R
+++ b/data-raw/release/upload_prediction_caches.R
@@ -1,0 +1,231 @@
+# upload_prediction_caches.R
+# Export prediction-relevant data from DuckDB to parquets and upload
+# to the predictions-cache release on peteowen1/bouncerdata.
+#
+# Run this locally after the heavy pipeline (steps 1-9) completes.
+# The GHA predictions workflow downloads these caches instead of
+# needing the full 18GB DuckDB.
+#
+# Usage:
+#   Rscript data-raw/release/upload_prediction_caches.R
+
+library(DBI)
+library(duckdb)
+library(piggyback)
+library(cli)
+
+# NOTE: Do NOT load arrow here — it invalidates DuckDB connections on Windows.
+# Instead, use DuckDB's built-in COPY TO for parquet export (no arrow needed).
+
+# Setup ----
+
+cli_h1("Export Prediction Caches")
+
+# Find bouncerdata directory (walk up from bouncer/)
+find_bouncerdata <- function() {
+  candidates <- c(
+    file.path(getwd(), "..", "bouncerdata"),
+    file.path(getwd(), "bouncerdata"),
+    "C:/Users/peteo/OneDrive/Documents/bouncerverse/bouncerdata"
+  )
+  for (d in candidates) {
+    db <- file.path(d, "bouncer.duckdb")
+    if (file.exists(db)) return(normalizePath(d, winslash = "/"))
+  }
+  cli_abort("Could not find bouncerdata directory")
+}
+
+bouncerdata_dir <- find_bouncerdata()
+db_path <- file.path(bouncerdata_dir, "bouncer.duckdb")
+cli_alert_info("Database: {db_path}")
+
+conn <- DBI::dbConnect(duckdb::duckdb(), dbdir = db_path, read_only = TRUE)
+on.exit(DBI::dbDisconnect(conn, shutdown = TRUE))
+
+# Helper: export query results to parquet using DuckDB's built-in COPY TO
+export_query_to_parquet <- function(conn, query, output_path) {
+  # Use DuckDB's native parquet writer (no arrow dependency)
+  escaped_path <- gsub("\\\\", "/", output_path)
+  copy_sql <- sprintf("COPY (%s) TO '%s' (FORMAT PARQUET, COMPRESSION ZSTD)", query, escaped_path)
+  DBI::dbExecute(conn, copy_sql)
+  size_mb <- file.size(output_path) / 1024 / 1024
+  # Count rows from the file
+  count <- DBI::dbGetQuery(conn, sprintf("SELECT COUNT(*) as n FROM read_parquet('%s')", escaped_path))$n
+  cli_alert_success("{basename(output_path)}: {format(count, big.mark=',')} rows, {round(size_mb, 1)} MB")
+}
+
+cache_dir <- file.path(tempdir(), "prediction_caches")
+dir.create(cache_dir, recursive = TRUE, showWarnings = FALSE)
+
+REPO <- "peteowen1/bouncerdata"
+TAG <- "predictions-cache"
+FORMATS <- c("t20", "odi", "test")
+
+# Ensure release exists
+tryCatch(
+
+  pb_release_create(repo = REPO, tag = TAG, name = "Prediction Caches"),
+  error = function(e) cli_alert_info("Release '{TAG}' already exists")
+)
+
+# 1. Match results (for form, H2H, venue stats) ----
+cli_h2("Exporting match results")
+
+export_query_to_parquet(conn, "
+  SELECT match_id, match_date, match_type, venue, team1, team2,
+         event_name, event_match_number, event_group,
+         team_type, gender, toss_winner, toss_decision,
+         outcome_winner, outcome_type, outcome_method
+  FROM cricsheet.matches
+  WHERE outcome_winner IS NOT NULL OR outcome_type IS NOT NULL
+  ORDER BY match_date
+", file.path(cache_dir, "matches.parquet"))
+
+# 2. Match innings (for venue avg scores) ----
+cli_h2("Exporting match innings")
+
+export_query_to_parquet(conn, "
+  SELECT mi.match_id, mi.innings, mi.total_runs, mi.batting_team
+  FROM cricsheet.match_innings mi
+", file.path(cache_dir, "match_innings.parquet"))
+
+# 3. Team ELO ----
+cli_h2("Exporting team ELO")
+
+export_query_to_parquet(conn, "
+  SELECT * FROM main.team_elo ORDER BY match_date
+", file.path(cache_dir, "team_elo.parquet"))
+
+# 4. Player skill indices (latest per player per format) ----
+cli_h2("Exporting player skill indices (latest per player)")
+
+for (fmt in FORMATS) {
+  skill_table <- paste0(fmt, "_player_skill")
+
+  export_query_to_parquet(conn, sprintf("
+    WITH ranked AS (
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY batter_id ORDER BY match_date DESC, delivery_id DESC) as rn
+      FROM main.%s WHERE batter_scoring_index IS NOT NULL
+    )
+    SELECT batter_id, match_date, batter_scoring_index, batter_survival_rate, batter_balls_faced
+    FROM ranked WHERE rn = 1
+  ", skill_table), file.path(cache_dir, paste0(fmt, "_batter_skill_latest.parquet")))
+
+  export_query_to_parquet(conn, sprintf("
+    WITH ranked AS (
+      SELECT *, ROW_NUMBER() OVER (PARTITION BY bowler_id ORDER BY match_date DESC, delivery_id DESC) as rn
+      FROM main.%s WHERE bowler_economy_index IS NOT NULL
+    )
+    SELECT bowler_id, match_date, bowler_economy_index, bowler_strike_rate, bowler_balls_bowled
+    FROM ranked WHERE rn = 1
+  ", skill_table), file.path(cache_dir, paste0(fmt, "_bowler_skill_latest.parquet")))
+}
+
+# 5. Player 3-Way ELO (latest per player per format) ----
+cli_h2("Exporting player 3-Way ELO (latest per player)")
+
+for (fmt in FORMATS) {
+  elo_table <- paste0(fmt, "_3way_elo")
+
+  # Check if table exists
+  exists_check <- tryCatch(
+    { DBI::dbGetQuery(conn, sprintf("SELECT 1 FROM main.%s LIMIT 1", elo_table)); TRUE },
+    error = function(e) FALSE
+  )
+  if (!exists_check) {
+    cli_alert_warning("Table {elo_table} not found, skipping")
+    next
+  }
+
+  export_query_to_parquet(conn, sprintf("
+    WITH ranked AS (
+      SELECT batter_id, match_date, batter_run_elo_after, batter_wicket_elo_after,
+             ROW_NUMBER() OVER (PARTITION BY batter_id ORDER BY match_date DESC, delivery_id DESC) as rn
+      FROM main.%s WHERE batter_run_elo_after IS NOT NULL
+    )
+    SELECT batter_id, match_date, batter_run_elo_after, batter_wicket_elo_after
+    FROM ranked WHERE rn = 1
+  ", elo_table), file.path(cache_dir, paste0(fmt, "_batter_elo_latest.parquet")))
+
+  export_query_to_parquet(conn, sprintf("
+    WITH ranked AS (
+      SELECT bowler_id, match_date, bowler_run_elo_after, bowler_wicket_elo_after,
+             ROW_NUMBER() OVER (PARTITION BY bowler_id ORDER BY match_date DESC, delivery_id DESC) as rn
+      FROM main.%s WHERE bowler_run_elo_after IS NOT NULL
+    )
+    SELECT bowler_id, match_date, bowler_run_elo_after, bowler_wicket_elo_after
+    FROM ranked WHERE rn = 1
+  ", elo_table), file.path(cache_dir, paste0(fmt, "_bowler_elo_latest.parquet")))
+}
+
+# 6. Prediction models ----
+cli_h2("Copying prediction models")
+
+models_dir <- file.path(bouncerdata_dir, "models")
+
+for (fmt in FORMATS) {
+  model_file <- file.path(models_dir, paste0(fmt, "_prediction_model.ubj"))
+  if (file.exists(model_file)) {
+    file.copy(model_file, file.path(cache_dir, basename(model_file)), overwrite = TRUE)
+    cli_alert_success("Copied {basename(model_file)}")
+  } else {
+    cli_alert_warning("Model not found: {basename(model_file)}")
+  }
+
+  features_file <- file.path(models_dir, paste0(fmt, "_prediction_features.rds"))
+  if (file.exists(features_file)) {
+    file.copy(features_file, file.path(cache_dir, basename(features_file)), overwrite = TRUE)
+    cli_alert_success("Copied {basename(features_file)}")
+  }
+}
+
+# 7. Recent team lineups (for XI inference) ----
+cli_h2("Exporting recent team lineups")
+
+export_query_to_parquet(conn, "
+  WITH recent_matches AS (
+    SELECT match_id, match_type, team1, team2, match_date, gender, team_type
+    FROM cricsheet.matches
+    WHERE match_date >= CURRENT_DATE - INTERVAL '6 months'
+  ),
+  player_appearances AS (
+    SELECT d.match_id, m.match_type, m.match_date, m.gender, m.team_type,
+           d.batting_team AS team, d.batter_id AS player_id
+    FROM cricsheet.deliveries d
+    JOIN recent_matches m ON d.match_id = m.match_id
+    UNION ALL
+    SELECT d.match_id, m.match_type, m.match_date, m.gender, m.team_type,
+           d.bowling_team AS team, d.bowler_id AS player_id
+    FROM cricsheet.deliveries d
+    JOIN recent_matches m ON d.match_id = m.match_id
+  )
+  SELECT DISTINCT match_id, match_type, match_date, gender, team_type, team, player_id
+  FROM player_appearances
+  ORDER BY match_date DESC
+", file.path(cache_dir, "recent_lineups.parquet"))
+
+# Upload all files ----
+cli_h2("Uploading to GitHub release")
+
+cache_files <- list.files(cache_dir, full.names = TRUE)
+cli_alert_info("Uploading {length(cache_files)} files to {REPO} tag '{TAG}'")
+
+for (f in cache_files) {
+  tryCatch({
+    pb_upload(f, repo = REPO, tag = TAG, overwrite = TRUE)
+    cli_alert_success("Uploaded {basename(f)}")
+  }, error = function(e) {
+    cli_alert_danger("Failed to upload {basename(f)}: {e$message}")
+  })
+}
+
+# Summary ----
+cli_h1("Upload Complete")
+
+total_size <- sum(file.size(cache_files)) / 1024 / 1024
+cli_alert_info("Total files: {length(cache_files)}")
+cli_alert_info("Total size: {round(total_size, 1)} MB")
+cli_alert_info("Release: {REPO} tag '{TAG}'")
+cli_alert_info("")
+cli_alert_info("Next: Run predictions workflow on GHA:")
+cli_alert_info("  gh workflow run predictions-pipeline.yml --repo peteowen1/bouncer --ref dev")

--- a/man/get_unscraped_matches.Rd
+++ b/man/get_unscraped_matches.Rd
@@ -7,7 +7,7 @@
 get_unscraped_matches(
   format = "all",
   gender = "all",
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -15,7 +15,7 @@ get_unscraped_matches(
 
 \item{gender}{Character. "male", "female", or "all" (default).}
 
-\item{source}{Character. "local" (default) or "remote".}
+\item{source}{Character. "remote" (default) or "local".}
 }
 \value{
 Data frame of unscraped fixtures.

--- a/man/get_upcoming_matches.Rd
+++ b/man/get_upcoming_matches.Rd
@@ -8,7 +8,7 @@ get_upcoming_matches(
   format = "all",
   gender = "all",
   days_ahead = 30,
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -18,7 +18,7 @@ get_upcoming_matches(
 
 \item{days_ahead}{Integer. Number of days ahead to look. Default 30.}
 
-\item{source}{Character. "local" (default) or "remote".}
+\item{source}{Character. "remote" (default) or "local".}
 }
 \value{
 Data frame of upcoming fixtures.

--- a/man/load_cricinfo_balls.Rd
+++ b/man/load_cricinfo_balls.Rd
@@ -8,7 +8,7 @@ load_cricinfo_balls(
   match_ids = NULL,
   format = NULL,
   gender = NULL,
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -19,7 +19,7 @@ If NULL, loads all.}
 
 \item{gender}{Character. "male", "female", or NULL (all genders).}
 
-\item{source}{Character. "local" (default) or "remote".}
+\item{source}{Character. "remote" (default) or "local".}
 }
 \value{
 Data frame of ball-by-ball data with Hawkeye columns.

--- a/man/load_cricinfo_fixtures.Rd
+++ b/man/load_cricinfo_fixtures.Rd
@@ -8,7 +8,7 @@ load_cricinfo_fixtures(
   format = "all",
   gender = "all",
   status = "all",
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -19,8 +19,8 @@ load_cricinfo_fixtures(
 \item{status}{Character. Match status filter: "all" (default), "POST"
 (completed), "PRE" (upcoming), "LIVE".}
 
-\item{source}{Character. "local" (default) queries DuckDB. "remote"
-downloads fixtures.parquet from the cricinfo GitHub release.}
+\item{source}{Character. "remote" (default) downloads fixtures.parquet
+from the cricinfo GitHub release. "local" queries DuckDB.}
 }
 \value{
 Data frame of fixtures.

--- a/man/load_cricinfo_innings.Rd
+++ b/man/load_cricinfo_innings.Rd
@@ -8,7 +8,7 @@ load_cricinfo_innings(
   match_ids = NULL,
   format = NULL,
   gender = NULL,
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -19,7 +19,7 @@ If NULL, loads all.}
 
 \item{gender}{Character. "male", "female", or NULL (all genders).}
 
-\item{source}{Character. "local" (default) or "remote".}
+\item{source}{Character. "remote" (default) or "local".}
 }
 \value{
 Data frame of batting scorecard data.

--- a/man/load_cricinfo_match.Rd
+++ b/man/load_cricinfo_match.Rd
@@ -8,7 +8,7 @@ load_cricinfo_match(
   match_ids = NULL,
   format = NULL,
   gender = NULL,
-  source = c("local", "remote")
+  source = c("remote", "local")
 )
 }
 \arguments{
@@ -19,7 +19,7 @@ If NULL, loads all.}
 
 \item{gender}{Character. "male", "female", or NULL (all genders).}
 
-\item{source}{Character. "local" (default) or "remote".}
+\item{source}{Character. "remote" (default) or "local".}
 }
 \value{
 Data frame of match metadata.


### PR DESCRIPTION
## Summary
- **Predictions pipeline**: GHA workflow (`predictions-pipeline.yml`) that downloads ~25MB of cached ratings from releases, builds temp DuckDB, predicts upcoming fixtures, uploads results. Triggered by `cricsheet-complete` dispatch or manual.
- **Upload script**: `upload_prediction_caches.R` exports DuckDB aggregates (skills, ELO, match history, models) to `predictions-cache` release
- **GHA prediction script**: `run_predictions_gha.R` — lightweight, no 18GB DuckDB needed
- **DATA_DICTIONARY.md**: Comprehensive column definitions for all DuckDB tables and computed features
- **Cricinfo as default**: Flipped `source` parameter default from "local" to "remote" in all cricinfo functions
- Plus: weather infrastructure, Test win probability models, constants consolidation, ELO/centrality improvements from prior dev work

## Test plan
- [x] `upload_prediction_caches.R` runs successfully (22 files, 25.2MB uploaded to predictions-cache release)
- [ ] `WORKFLOW_PAT` secret added to bouncer repo
- [ ] Trigger predictions-pipeline.yml manually after merge
- [ ] Verify predictions parquet generated and uploaded to predictions-latest release
- [ ] pkgdown builds successfully (all NAMESPACE exports in _pkgdown.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)